### PR TITLE
[bug] allow files excluded from vscode settings to be found

### DIFF
--- a/src/lcovReport.ts
+++ b/src/lcovReport.ts
@@ -93,7 +93,10 @@ function runCoverage() {
 
     // check if file path must be changed to absolute
     if (!path.isAbsolute(searchPath)) {
-      vscode.workspace.findFiles(searchPath).then((files) => {
+      // https://code.visualstudio.com/api/references/vscode-api
+      // pass in null to vscode workspace find files to search all files matched in filepath
+      // even if the filepath is in the workspace files.exclude setting of vscode
+      vscode.workspace.findFiles(searchPath, null).then((files) => {
         if (files.length > 0) {
           activeLcovFile = files[0].fsPath;
           return loadLcovFromFileAndApplyCoverage(resolve, reject);


### PR DESCRIPTION
Hi 👋 !

I noticed a small weird interaction where vscode.workspace.findFiles will not work properly if the file passed in is in the user's file.excluded settings.

I.e, if we have the following folders excluded from vscode search because it slows down vscode's performance, but coverage files are also stored here. 
```
  "files.exclude": {
    "**/bazel-bin": true,
    "**/bazel-out": true,
    "**/bazel-testlogs": true,
    "**/outputs": true
  },
```

Thus, if we try to link `**/bazel-out/_coverage/_coverage_report.dat` as the lcov file, vscode will fail to return any files unless we mark the second parameter exclude as Null

![image](https://github.com/user-attachments/assets/6fd7318e-e704-4336-af7b-08aa324b1b04)
